### PR TITLE
Use latest FlexibleClient version instead of fixed one

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To try out the _BasicUserControl_ and _BasicExternalObject_ samples you may wish
 - Run the command `gradlew uploadArchives` from the `SampleModule` directory.
 
 ### Considerations
-- Take into account that this project uses the latest `FlexibleClient` version installed at `GENEXUS_REPO`. If you need to work with an specific one, you will have to replace it in [library/build.gradle](https://github.com/genexuslabs/SDExtensionsSample/blob/master/SampleModule/library/build.gradle) file.
+- Take into account that this project uses the latest `FlexibleClient` version installed at `GENEXUS_REPO`. If you need to work with a specific one, you will have to replace it in [library/build.gradle](https://github.com/genexuslabs/SDExtensionsSample/blob/master/SampleModule/library/build.gradle) file.
 
 ## Further reading
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ To try out the _BasicUserControl_ and _BasicExternalObject_ samples you may wish
     - `ANDROID_HOME` to your Android SDK directory.
 - Run the command `gradlew uploadArchives` from the `SampleModule` directory.
 
+### Considerations
+- Take into account that this project uses the latest `FlexibleClient` version installed at `GENEXUS_REPO`. If you need to work with an specific one, you will have to replace it in [library/build.gradle](https://github.com/genexuslabs/SDExtensionsSample/blob/master/SampleModule/library/build.gradle) file.
+
 ## Further reading
 
 ### User Controls

--- a/SampleModule/library/build.gradle
+++ b/SampleModule/library/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.genexus:FlexibleClient:16.9'
+    implementation 'com.genexus:FlexibleClient:+'
 }
 
 apply from: rootProject.file('gradle-mvn-push.gradle')


### PR DESCRIPTION
Ahora que se armó una prueba para este repositorio, se podría pasar a indicar que se tome la última versión publicada del FlexibleClient en el repositorio de la instalación de GX y así evitar problemas de referencias cuando se quiere probar el proyecto con una versión de GX diferente a la que indica el archivo `build.gradle`.

Esto también serviría para el caso de la prueba automatizada dado que permitiría que se corra con Trunk sin tener que configurar la versión como `17.0-SNAPSHOT`.